### PR TITLE
fix: initial sort order

### DIFF
--- a/features/leaderboard/components/leaderboard/table.tsx
+++ b/features/leaderboard/components/leaderboard/table.tsx
@@ -123,7 +123,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
             >
               <TableSortLabel
                 active={orderBy === headCell.field}
-                direction={orderBy === headCell.field ? order : 'asc'}
+                direction={orderBy === headCell.field ? order : 'desc'}
                 onClick={createSortHandler(headCell.field)}
                 sx={{
                   color: `${headCell.color} !important`,
@@ -225,8 +225,8 @@ export const Leaderboard = () => {
     event: React.MouseEvent<unknown>,
     property: keyof Data,
   ) => {
-    const isAsc = orderBy === property && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
+    const isDesc = orderBy === property && order === 'desc';
+    setOrder(isDesc ? 'asc' : 'desc');
     setOrderBy(property);
   };
 


### PR DESCRIPTION
Changed sort order to desc on the first click:

https://github.com/strongholdsec/leaderboard/assets/25568730/f460533d-09d4-4d79-8649-112952376dd3

This behaviour shows top users and seems to be more logical than current behaviour that shows outsiders first 
Old behaviour:

https://github.com/strongholdsec/leaderboard/assets/25568730/025a519e-8f89-4e97-9f98-08271fff015e

