### PR TITLE
fix: added support for avatars stored on IPFS

### DIFF
--- a/hooks/useContestInfo.ts
+++ b/hooks/useContestInfo.ts
@@ -9,6 +9,7 @@ import { IAuditorResult, ICompetitionTop } from '../types';
 import { STRATEGY_LAZY } from '../utils/cacheStrategies';
 import { parseTokenParams } from '../utils/parseTokenParams';
 import { MultiEnsResolverContractConfig } from 'abis/MultiEnsResolver';
+import { parseAvatarLink } from 'utils/parseAvatarLink';
 
 const SBTTransferEventDetails = {
   ...SBTContractConfig,
@@ -160,7 +161,7 @@ export const useContestInfo = (): UseQueryResult<ContestInfo, Error> => {
         const packedResults = uniqueUsers.map(
           (address, i) => {
             userResults[address].profile.name = names[i];
-            userResults[address].profile.avatar = avatars[i][0];
+            userResults[address].profile.avatar = parseAvatarLink(avatars[i][0]);
             return userResults[address];
           },
         );

--- a/utils/parseAvatarLink.ts
+++ b/utils/parseAvatarLink.ts
@@ -1,0 +1,3 @@
+export const parseAvatarLink = (avatarLink: string) => {
+    return avatarLink.replace('ipfs://', 'https://ipfs.io/ipfs/');
+}


### PR DESCRIPTION
Before avatar links with ipfs:// protocol were not supported
<img width="333" alt="image" src="https://github.com/strongholdsec/leaderboard/assets/25568730/fca111d5-9318-425c-bb79-b03a7743ec53">
After:
<img width="333" alt="image" src="https://github.com/strongholdsec/leaderboard/assets/25568730/b23a559a-06c0-4711-b7d6-1b7be5c0ea98">
