### PR TITLE
fix: fixed empty cell col span

### DIFF
--- a/features/leaderboard/components/leaderboard/table.tsx
+++ b/features/leaderboard/components/leaderboard/table.tsx
@@ -372,7 +372,7 @@ export const Leaderboard = () => {
                     height: 53 * emptyRows,
                   }}
                 >
-                  <TableCell colSpan={8} />
+                  <TableCell colSpan={9} />
                 </TableRow>
               )}
             </TableBody>


### PR DESCRIPTION
Before:
<img width="1183" alt="image" src="https://github.com/strongholdsec/leaderboard/assets/25568730/e210808b-a343-4bd5-85f9-a675c80faad2">
After:
<img width="1183" alt="image" src="https://github.com/strongholdsec/leaderboard/assets/25568730/4ffb7366-6ee6-4b92-8968-a8a91c6e7ee8">
